### PR TITLE
Blockstack cli version 0.0.13.24: no config

### DIFF
--- a/app/docs/tutorials/extended-usage.md
+++ b/app/docs/tutorials/extended-usage.md
@@ -109,7 +109,7 @@ Example response:
 To update the blockstack server that your command line client is connecting to, use the `blockstack config` command:
 
 ```bash
-# blockstack config --host=server.blockstack.org --port=6264 --advanced=off
+# blockstack configure --host=server.blockstack.org --port=6264 --advanced=off
 ```
 
 Expected response:


### PR DESCRIPTION
Blockstack cli version 0.0.13.24 does not support the "config" option. Changed to "configure"
