### PR TITLE
remove forum link

### DIFF
--- a/app/docs/docs/namespaces.md
+++ b/app/docs/docs/namespaces.md
@@ -70,4 +70,4 @@ The first namespace ever created is one for referring to user identities (TLD: <
   </tbody>
 </table>
 
-For help creating your own namespace, reach out to other Blockstack members in [the Blockstack Forum](http://forum.blockstack.org) or [the Blockstack Slack group](http://chat.blockstack.org).
+For help creating your own namespace, reach out to other Blockstack members in [the Blockstack Slack group](http://chat.blockstack.org).


### PR DESCRIPTION
There was a link to the old forum in the namespaces docs. Removed it.

<img width="793" alt="screen shot 2016-11-02 at 3 47 48 pm" src="https://cloud.githubusercontent.com/assets/597182/19920478/c9fedeac-a113-11e6-9bef-afad7cd85457.png">
