### PR TITLE
update: cli-installation.md

### DIFF
--- a/app/docs/docs/cli-installation.md
+++ b/app/docs/docs/cli-installation.md
@@ -30,7 +30,7 @@ $ sudo pip install blockstack
 Installation on Debian + Ubuntu requires `pip` and `libssl`. First, make sure you have both:
 
 ```bash
-$ sudo apt-get update && sudo apt-get install -y python-pip python-dev libssl-dev
+$ sudo apt-get update && sudo apt-get install -y python-pip python-dev libssl-dev libffi-dev rng-tools
 ```
 
 Next, use `pip` to install blockstack:


### PR DESCRIPTION
If the `libffi-dev` and `rng-tools` packages are not installed before running `sudo pip install blockstack`, Python's `cryptography` lib will fail to build. This behavior was observed when building from within a `virtualenv`.