### PR TITLE
#222 Docs Page Contents Shrink On Mobile View

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -367,7 +367,7 @@ footer > li{list-style:none;}
   .card-deck-wrapper{margin-bottom:35px;}
   .paper-section{padding-top:65px;padding-bottom:65px;}
   .sidebar{position:fixed;top:56px;bottom:0;left:0;z-index:1000;display:block;padding:0px 20px 20px 20px;overflow-x:hidden;overflow-y:auto; /* Scrollable contents if viewport is shorter than content. */background-color:#f5f5f5;border-right:1px solid #eee;}
-  .bitcoin-protocols-main{padding-right:40px;padding-left:40px;}  
+  .bitcoin-protocols-main{padding-right:40px;padding-left:40px;}
 }
 
 /* Medium devices (desktops, 992px and up) */
@@ -429,4 +429,8 @@ footer > li{list-style:none;}
 /* x-Small devices (hide last child in navbar) */
 @media (max-width:348px){
   li.nav-item:nth-last-child(2){display:none;}
+}
+
+@media (max-width:450px){
+  section{word-break:break-word;}
 }


### PR DESCRIPTION
Added a break-word to the section on mobile sizes of 450px or less to prevent the DOCS page from being made smaller. This was being caused by some of the red letter code expanding over the border of their container.