### PR TITLE
Docs mobile sizing fix on @media break point

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -431,6 +431,6 @@ footer > li{list-style:none;}
   li.nav-item:nth-last-child(2){display:none;}
 }
 
-@media (max-width:450px){
+@media (max-width:575px){
   section{word-break:break-word;}
 }


### PR DESCRIPTION
Sorry this was merged before i could get the correction we discussed in #248 where i set the break to 450px, this has now been changed to the bootstrap standard break point for x-small devices