### PR TITLE
Use a single repo for docs 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "app/blockstack"]
+	path = app/blockstack
+	url = https://github.com/blockstack/blockstack.git

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A live version of this site can be found online at https://blockstack.org.
 ### Installation
 
 ```
-$ git clone git@github.com:blockstack/blockstack-site.git
+$ git clone --recursive git@github.com:blockstack/blockstack-site.git
 $ npm install
 ```
 
@@ -22,6 +22,15 @@ $ gulp dev
 To run the site in development mode, run `gulp dev` (this may require installing Gulp globally `npm install gulp -g`). Your browser will automatically be opened and directed to the browser-sync proxy address.
 
 Now that `gulp dev` is running, the server is up as well and serving files from the `/build` directory. Any changes in the `/app` directory will be automatically processed by Gulp and the changes will be injected to any open browsers pointed at the proxy address.
+
+This repo uses [Git Submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) and links to the [blockstack](https://github.com/blockstack/blockstack) repo.
+You can pull new changes from the blockstack repo by:
+
+```
+$ git submodule update --remote
+```
+
+For simplicity, please make any edits to the .md files directly in the [blockstack](https://github.com/blockstack/blockstack) repo instead of the submodule linked from this repo.
 
 #### Upgrading Blockstack Bootstrap
 

--- a/app/js/pages/ArticlePage.js
+++ b/app/js/pages/ArticlePage.js
@@ -110,7 +110,7 @@ class ArticlePage extends Component {
           title = currentPage ? currentPage.title : "Docs"
     const headerImageSrc = this.state.currentPage ? this.state.currentPage.image : null
     const pathPrefix = '/' + location.pathname.split('/')[1]
-    const githubFileUrlRoot = "https://github.com/blockstack/blockstack-site/blob/master/app/docs"
+    const githubFileUrlRoot = "https://github.com/blockstack/blockstack/blob/master"
 
     return (
       <DocumentTitle title={title}>

--- a/gulp/tasks/buildDocs.js
+++ b/gulp/tasks/buildDocs.js
@@ -79,10 +79,10 @@ gulp.task('buildDocs', () => {
   let folderNames = ['articles', 'tutorials', 'docs', 'posts', 'overview']
 
   folderNames.forEach((folderName) => {
-    fs.readdirSync('app/docs/' + folderName).forEach((docFilename) => {
+    fs.readdirSync('app/blockstack/' + folderName).forEach((docFilename) => {
       let key = docFilename.split('.')[0].toLowerCase(),
           docProperties = {},
-          docPage = fs.readFileSync('app/docs/' + folderName + '/' + docFilename, 'utf8'),
+          docPage = fs.readFileSync('app/blockstack/' + folderName + '/' + docFilename, 'utf8'),
           pageSections = docPage.split('---')
       
       let description = '',

--- a/gulp/tasks/buildWhitepaper.js
+++ b/gulp/tasks/buildWhitepaper.js
@@ -1,0 +1,129 @@
+'use strict';
+
+import gulp                      from 'gulp'
+import config                    from '../config'
+import fs                        from 'fs'
+import metaData                  from 'meta-tag-data'
+import request                   from 'request'
+import {parseString as parseXML} from 'xml2js'
+import {getPostFromRSS}          from '../../app/js/utils/rssUtils'
+
+function createMetatagMarkup(url, title, description, image) {
+  let metatagMarkup = '<meta charset="utf-8" />\n'
+  metatagMarkup += `<title>Blockstack - ${title}</title>\n`
+
+  let metadata = metaData('name', {
+    'description': description,
+    'viewport': 'width=device-width',
+    'twitter:card': 'summary_large_image',
+    'twitter:site': '@blockstackorg',
+    'twitter:title': title,
+    'twitter:description': description,
+    'twitter:image': image
+  })
+  metadata.forEach((datum) => {
+    metatagMarkup += `<meta name="${datum.name}" content="${datum.content}" />\n`
+  })
+  let metadata2 = metaData('property', {
+    'og:title': title,
+    'og:type': 'website',
+    'og:url': url,
+    'og:image': image,
+    'og:description': description
+  })
+  metadata2.forEach((datum) => {
+    metatagMarkup += `<meta property="${datum.property}" content="${datum.content}" />\n`
+  })
+  metatagMarkup += '<link rel="alternate" type="application/rss+xml" title="Blockstack Blog" href="https://blockstack-site-api.herokuapp.com/v1/blog-rss" />'
+
+  return metatagMarkup
+}
+
+gulp.task('buildBlog', () => {
+  function createBlogPostRecord(indexHtml, rssPost) {
+    const post = getPostFromRSS(rssPost)
+    const metatagMarkup = createMetatagMarkup(
+      post.url, post.title, post.description, post.image)
+    const modifiedIndex = indexHtml.replace('<meta charset="utf-8" />', metatagMarkup)
+    fs.writeFileSync('build/blog-' + post.urlSlug + '.html', modifiedIndex)    
+  }
+
+  function createBlogRecords(indexHtml, rssJSON) {
+    const firstChannel = rssJSON.rss.channel[0]
+    firstChannel.item.map((post) => {
+      createBlogPostRecord(indexHtml, post)
+    })
+  }
+
+  const indexHtml = fs.readFileSync('app/index.html', 'utf8')
+  const rssURL = "https://blockstack-site-api.herokuapp.com/v1/blog-rss"
+  request({
+    url: rssURL,
+    withCredentials: false
+  }, (error, response, body) => {
+    if (!error && response.statusCode === 200) {
+      parseXML(body, (err, rssJSON) => {
+        createBlogRecords(indexHtml, rssJSON)
+      })
+    } else {
+      console.log(error)
+    }
+  })
+})
+
+gulp.task('buildDocs', () => {
+  let allDocs = {}
+
+  let indexHtml = fs.readFileSync('app/index.html', 'utf8')
+
+  let folderNames = ['whitepaper']
+
+  folderNames.forEach((folderName) => {
+    fs.readdirSync('app/blockstack/' + folderName).forEach((docFilename) => {
+      let key = docFilename.split('.')[0].toLowerCase(),
+          docProperties = {},
+          docPage = fs.readFileSync('app/blockstack/' + folderName + '/' + docFilename, 'utf8'),
+          pageSections = docPage.split('<!--- -->')
+      
+      let description = '',
+          image = 'https://blockstack.org' + '/images/article-photos/chalkboard.jpg',
+          title = '',
+          url = 'https://blockstack.org/' + folderName + '/' + key
+
+      if (pageSections.length === 3) {
+        docProperties.markdown = pageSections[2]
+        let propertyLines = pageSections[1].split('\n')
+        propertyLines.map((propertyLine) => {
+          if (propertyLine.split(': ').length >= 2) {
+            let parts = propertyLine.split(': ')
+            let propertyName = parts[0],
+                propertyValue = parts.slice(1).join(': ')
+            if (propertyName === 'description') {
+              description = propertyValue
+            }
+            if (propertyName === 'image') {
+              image = 'https://blockstack.org' + propertyValue
+            }
+            if (propertyName === 'chapter') {
+              title = propertyValue
+            }
+            docProperties[propertyName] = propertyValue.trim()
+          }
+        })
+      }
+      // Just use a default image instead of specifying header images for each chapter
+      docProperties['image'] = image
+      allDocs[key] = docProperties
+
+      let metatagMarkup = createMetatagMarkup(url, title, description, image)
+      let modifiedIndex = indexHtml.replace('<meta charset="utf-8" />', metatagMarkup)
+      fs.writeFileSync('build/docs-' + folderName + '-' + key + '.html', modifiedIndex)
+    })
+  })
+
+  fs.writeFile('app/docs.json', JSON.stringify(allDocs), (err) => {
+    if (err) {
+      throw err
+    }
+  })
+})


### PR DESCRIPTION
I edited the blockstack.org framework to pull content directly from the [blockstack repo](https://github.com/blockstack/blockstack). For me the biggest friction points for editing the .md files for the website were: 

- Getting the node.js website running locally (I was just being lazy and never installed node.js and got the site to work locally -- but I feel there might be others like me as well)
- The .md files were hidden in subdirectories and it wasn't easy for me to see how they look on the website

I've added blockstack/blockstack as a submodule and made the appropriate changes in the blockstack-site framework. The "edit this post on Github" link should also work and direct everyone to blockstack/blockstack which is a much more popular repo and we want everyone to make edits/commits there. 

I've also added instructions for working with submodule and they're fairly straight forward. All changes go to blockstack/blockstack and we'll occasionally pull the latest from there.