### PR TITLE
Add Todo tutorial

### DIFF
--- a/app/js/config.js
+++ b/app/js/config.js
@@ -79,6 +79,12 @@ export const tutorials = {
     urlSlug: 'cli-basics',
     description: 'Walk through the basics of the command line interface, like looking up names, getting name prices, and registering names.'
   },
+  'todo-spa': {
+    image: '/images/tutorials/cli-lookups.jpg',
+    title: 'Blockstak Todos',
+    urlSlug: 'todo-spa',
+    description: 'Walk through creating a basic Todo application with Blockstack. Learn about Sign In flow and Gaia storage.'
+  },
 }
 
 export const talks = {

--- a/firebase.json
+++ b/firebase.json
@@ -56,8 +56,8 @@
         "destination": "/docs-tutorials-hello-blockstack.html"
       },
       {
-        "source": "/blog/untitled",
-        "destination": "/blog-untitled.html"
+        "source": "/blog/announcing-blockstack-token-and-mining",
+        "destination": "/blog-announcing-blockstack-token-and-mining.html"
       },
       {
         "source": "/blog/blockstack-and-the-power-of-choice",
@@ -209,6 +209,11 @@
       {
         "source": "/tutorials/hello-world",
         "destination": "/tutorials/hello-blockstack",
+        "type": 301
+      },
+      {
+        "source": "/tutorials/todo-spa",
+        "destination": "/tutorials/todo-spa",
         "type": 301
       },
       {

--- a/gulp/tasks/configFirebase.js
+++ b/gulp/tasks/configFirebase.js
@@ -127,6 +127,10 @@ gulp.task('configFirebase', () => {
       'destination': '/tutorials/hello-blockstack',
     },
     {
+      'source': '/tutorials/todo-spa',
+      'destination': '/tutorials/todo-spa',
+    },
+    {
       'source': '/docs/cli-basic-usage',
       'destination': '/tutorials/cli-basics'
     },


### PR DESCRIPTION
This PR is a companion to https://github.com/blockstack/blockstack/pull/319. It changes `gulp/tasks/configFirebase.js` and `app/js/config.js` to add a new tutorial to the tutorials page. 

I had some trouble testing this locally as I was unable to get the `todo-spa.md` file from `blockstack/blockstack` to pull into the local git submodule. @shea256 @larrysalibra 