### PR TITLE
ensure consistent spelling of JavaScript

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -52,7 +52,7 @@
         <div className="col-md-6 paper-wrap">
           <div class="card card-inverse card-danger text-xs-center card-rectangular">
             <div class="card-block">
-              <h3 class="card-title">Javascript Required</h3>
+              <h3 class="card-title">JavaScript Required</h3>
               <blockquote class="card-blockquote">
                 <p>
                   <strong>Oh snap!</strong> Your browser doesn't support JavaScript. Please enable it to view this site.

--- a/app/js/pages/AboutPage.js
+++ b/app/js/pages/AboutPage.js
@@ -26,23 +26,23 @@ class AboutPage extends Component {
                       In Short
                     </h2>
                     <p className="mb-5">
-                      Blockstack is a new internet for decentralized apps that you access through 
-                      the <a href="/install">Blockstack Browser</a>. With Blockstack, there is a 
-                      new world of apps that let you own your data and maintain your privacy, 
+                      Blockstack is a new internet for decentralized apps that you access through
+                      the <a href="/install">Blockstack Browser</a>. With Blockstack, there is a
+                      new world of apps that let you own your data and maintain your privacy,
                       security and freedom.
                     </p>
                     <h2>
                       How It Works
                     </h2>
                     <p>
-                      Blockstack uses the lower layers of the traditional internet and focuses on 
-                      decentralizing the application layer. Blockstack provides key tools and 
-                      infrastructure to developers enabling decentralized storage and decentralized 
-                      authentication & identity. Developers build single-page applications in 
-                      Javascript then plug into user-run APIs, which eliminates centralized points 
-                      of control. Users run decentralized apps through the Blockstack browser and 
-                      give explicit read/write permissions to their data. Information is encrypted 
-                      and stored on users’ personal devices. There are no middlemen, no passwords, 
+                      Blockstack uses the lower layers of the traditional internet and focuses on
+                      decentralizing the application layer. Blockstack provides key tools and
+                      infrastructure to developers enabling decentralized storage and decentralized
+                      authentication & identity. Developers build single-page applications in
+                      JavaScript then plug into user-run APIs, which eliminates centralized points
+                      of control. Users run decentralized apps through the Blockstack browser and
+                      give explicit read/write permissions to their data. Information is encrypted
+                      and stored on users’ personal devices. There are no middlemen, no passwords,
                       and no massive data silos to breach.
                     </p>
                     <p>
@@ -50,8 +50,8 @@ class AboutPage extends Component {
                       </a> (available for Mac, Windows, and Linux).
                     </p>
                     <p className="mb-5">
-                      There are many Blockstack apps already in production and more being built 
-                      every day with the participation of the online open source community and in 
+                      There are many Blockstack apps already in production and more being built
+                      every day with the participation of the online open source community and in
                       partnership with VC Bounties Programs. See more on that at <a href="/funding">
                       blockstack.org/funding</a>
                     </p>
@@ -82,37 +82,37 @@ class AboutPage extends Component {
                         Blockstack is a Public Benefit Corp
                       </h2>
                       <p className="mb-5">
-                        Blockstack is both an open source project and a Public Benefit Corporation 
-                        (PBC). Blockstack PBC, a Public Benefit Corp, upholds specific commitments 
-                        to the greater public good in addition to stockholder interests. 
-                        The mission of Blockstack PBC is to enable an open, decentralized internet. 
-                        Blockstack PBC is committed to always keep the core Blockstack software 
-                        open-source, and to support the decentralization of the Blockstack network. 
-                        Blockstack PBC has historically taken the lead on Blockstack protocol 
-                        development, but in the future will work with other parties to build a 
-                        fully transparent and adaptable decentralized internet.  
+                        Blockstack is both an open source project and a Public Benefit Corporation
+                        (PBC). Blockstack PBC, a Public Benefit Corp, upholds specific commitments
+                        to the greater public good in addition to stockholder interests.
+                        The mission of Blockstack PBC is to enable an open, decentralized internet.
+                        Blockstack PBC is committed to always keep the core Blockstack software
+                        open-source, and to support the decentralization of the Blockstack network.
+                        Blockstack PBC has historically taken the lead on Blockstack protocol
+                        development, but in the future will work with other parties to build a
+                        fully transparent and adaptable decentralized internet.
                       </p>
                       <h2>
                         History
                       </h2>
                       <p className="mb-5">
-                        Blockstack was started by Muneeb Ali and Ryan Shea in 2013. The first public 
-                        launch of a registrar service (called the Onename App) was in March 2014 and 
-                        the company went through Y Combinator in summer 2014. After YC, the company 
-                        raised a Seed round led by Union Square Ventures. The company closed a Series 
-                        A in January 2017, again led by Union Square Ventures, with investors including 
-                        Lux Capital, Naval Ravikant, and Shana Fisher. Blockstack became a Public 
+                        Blockstack was started by Muneeb Ali and Ryan Shea in 2013. The first public
+                        launch of a registrar service (called the Onename App) was in March 2014 and
+                        the company went through Y Combinator in summer 2014. After YC, the company
+                        raised a Seed round led by Union Square Ventures. The company closed a Series
+                        A in January 2017, again led by Union Square Ventures, with investors including
+                        Lux Capital, Naval Ravikant, and Shana Fisher. Blockstack became a Public
                         Benefit Corp in September 2017.
                       </p>
                       <h2>
                         Blockstack Values
                       </h2>
                       <p>
-                        Blockstack is an open-source project with core developers and contributors 
-                        located around the world, from New York City to Hong Kong. We believe the 
-                        community is one of our greatest assets, and the team engages with users via 
-                        Slack, Github, Twitter, and the Blockstack Forum in order to build the best 
-                        product possible. 
+                        Blockstack is an open-source project with core developers and contributors
+                        located around the world, from New York City to Hong Kong. We believe the
+                        community is one of our greatest assets, and the team engages with users via
+                        Slack, Github, Twitter, and the Blockstack Forum in order to build the best
+                        product possible.
                       </p>
                       <p>
                         Blockstack Team Values: (voted and decided collaboratively by the team)

--- a/app/js/pages/IntroPage.js
+++ b/app/js/pages/IntroPage.js
@@ -37,7 +37,7 @@ class IntroPage extends Component {
             <p>
               The applications on blockstack are server-less and decentralized.
 
-              Developers start by building a single-page application in Javascript,
+              Developers start by building a single-page application in JavaScript,
 
               Then, instead of plugging the frontend into a centralized API,
               they plug into an API run by the user.

--- a/app/js/pages/TokenSalePage.js
+++ b/app/js/pages/TokenSalePage.js
@@ -169,7 +169,7 @@ export default connect(mapStateToProps, mapDispatchToProps)(TokenSalePage)
                         <p>
                           The applications on blockstack are server-less and decentralized.
 
-                          Developers start by building a single-page application in Javascript,
+                          Developers start by building a single-page application in JavaScript,
 
                           Then, instead of plugging the frontend into a centralized API,
                           they plug into an API run by the user.


### PR DESCRIPTION
I find most public references to the language specify `JavaScript`. Yay for trademarked grammar consistency.