### PR TITLE
remove trailing slash redirects

### DIFF
--- a/gulp/tasks/configFirebase.js
+++ b/gulp/tasks/configFirebase.js
@@ -63,14 +63,6 @@ gulp.task('configFirebase', () => {
       'destination': 'https://blockstack.com'
     },
     {
-      'source': '/summit2017/',
-      'destination': '/summit2017'
-    },
-    {
-      'source': '/funding/',
-      'destination': '/funding'
-    },
-    {
       'source': '/fund',
       'destination': '/funding'
     },


### PR DESCRIPTION
We had rules for firebase redirecting /funding/ to /funding and /summit2017/ to /summit2017 - netlify's [CDN edge nodes do trailing slash url normalization before the `_redirects` rules are processed](https://www.netlify.com/docs/redirects/#trailing-slash), so these rules were preventing loading of these two pages. 

You can see that after this pull request, both pages load directly:
https://5a69d3ffa6188f3ea840d3b9--blockstack.netlify.com/funding
https://5a69d3ffa6188f3ea840d3b9--blockstack.netlify.com/summit2017