### PR TITLE
switch site api endpoint #485

### DIFF
--- a/app/js/datastore/Blog.js
+++ b/app/js/datastore/Blog.js
@@ -28,8 +28,8 @@ function updatePosts(postPages) {
 function fetchPosts() {
   return dispatch => {
     const urls = [
-      'https://blockstack-site-api.herokuapp.com/v1/blog-rss?page=1',
-      'https://blockstack-site-api.herokuapp.com/v1/blog-rss?page=2',
+      'https://site-api.blockstack.org/v1/blog-rss?page=1',
+      'https://site-api.blockstack.org/v1/blog-rss?page=2',
     ]
 
     const promises = urls.map(url =>

--- a/app/js/datastore/Stats.js
+++ b/app/js/datastore/Stats.js
@@ -22,7 +22,7 @@ function updateStats(stats) {
 
 function fetchStats() {
   return dispatch => {
-    const url = 'https://blockstack-site-api.herokuapp.com/v1/stats'
+    const url = 'https://site-api.blockstack.org/v1/stats'
     fetch(url)
     .then((response) => response.text())
     .then((responseText) => JSON.parse(responseText))

--- a/app/metatags.html
+++ b/app/metatags.html
@@ -9,7 +9,7 @@
 <meta name="apple-mobile-web-app-status-bar-style" content="black" />
 
 <!-- RSS feed -->
-<link rel="alternate" type="application/rss+xml" title="Blockstack Blog" href="https://blockstack-site-api.herokuapp.com/v1/blog-rss" />
+<link rel="alternate" type="application/rss+xml" title="Blockstack Blog" href="https://site-api.blockstack.org/v1/blog-rss" />
 
 <!-- Twitter Card data -->
 <meta name="twitter:card" content="summary_large_image" />

--- a/gulp/tasks/buildDocs.js
+++ b/gulp/tasks/buildDocs.js
@@ -37,7 +37,7 @@ function createMetatagMarkup(url, title, description, image) {
   metadata2.forEach((datum) => {
     metatagMarkup += `<meta property="${datum.property}" content="${datum.content}" />\n`
   })
-  metatagMarkup += '<link rel="alternate" type="application/rss+xml" title="Blockstack Blog" href="https://blockstack-site-api.herokuapp.com/v1/blog-rss" />'
+  metatagMarkup += '<link rel="alternate" type="application/rss+xml" title="Blockstack Blog" href="https://site-api.blockstack.org/v1/blog-rss" />'
 
   return metatagMarkup
 }
@@ -59,7 +59,7 @@ gulp.task('buildBlog', () => {
   }
 
   const indexHtml = fs.readFileSync('app/index.html', 'utf8')
-  const rssURL = 'https://blockstack-site-api.herokuapp.com/v1/blog-rss'
+  const rssURL = 'https://site-api.blockstack.org/v1/blog-rss'
   request({
     url: rssURL,
     withCredentials: false

--- a/gulp/tasks/configFirebase.js
+++ b/gulp/tasks/configFirebase.js
@@ -29,7 +29,7 @@ gulp.task('configFirebase', () => {
   })
 
   // Create rewrites for blog
-  const rssURL = 'https://blockstack-site-api.herokuapp.com/v1/blog-rss'
+  const rssURL = 'https://site-api.blockstack.org/v1/blog-rss'
   const requestBody = request('GET', rssURL).body
   parseXML(requestBody, (err, blogRSSData) => {
     const firstChannel = blogRSSData.rss.channel[0]


### PR DESCRIPTION
This pull request switches the site api endpoint to site-api.blockstack.org instead of the heroku domain. This will let us enable cloudflare's caching CDN reverse proxy which will improve blog load speed.

See https://github.com/blockstack/blockstack.org-api/issues/1