### PR TITLE
add link to community site

### DIFF
--- a/app/js/components/Footer.js
+++ b/app/js/components/Footer.js
@@ -107,6 +107,11 @@ class Footer extends Component {
                         Swag Shop
                       </a>
                     </div>
+                    <div className="foot-item">
+                      <Link to={links.community} target="_blank">
+                        Community Site
+                      </Link>
+                    </div>
                   </div>
                 </div>
                 <div className="col-6 col-md-3">

--- a/app/js/config.js
+++ b/app/js/config.js
@@ -12,6 +12,7 @@ export const socialLinks = {
   blog: 'http://blog.blockstack.org',
   github: 'https://github.com/blockstack',
   branding: 'https://projects.invisionapp.com/boards/HE2VVROFSGB27/',
+  community: 'https://community.blockstack.org/',
 }
 
 export const installationLinks = {


### PR DESCRIPTION
It looks like no one is taking https://github.com/blockstack/blockstack.org/issues/536. :)

![image](https://user-images.githubusercontent.com/1841581/38663629-2d572740-3dec-11e8-916f-7f2941f04db9.png)

Please let me know if I can use a better copy. I used "Community Site" instead of "Community" because the section name for these external links are already called "Community" so there might be some confusion to the user if the link itself has the same text again.

Would really appreciate your review!