### PR TITLE
Hotfix: Image size fix

### DIFF
--- a/components/image/index.js
+++ b/components/image/index.js
@@ -30,7 +30,6 @@ class Image extends React.Component {
       : null
     const source = internalLink ? addPath(localImage.src) : src
     const placeholder = internalLink ? localImage.placeholder : null
-    console.log(localImage)
     const Placeholder = () =>
       !noBlur || !internalLink ? (
         <StyledImage.Placeholder>

--- a/components/image/index.js
+++ b/components/image/index.js
@@ -3,8 +3,8 @@ import { StyledImage } from './styled'
 const requireImage = require.context('@assets', true, /\.(png|jpg|jpeg|svg)$/)
 const path = '/_next/'
 const addPath = (src) => {
-  if(!src.includes(path)){
-      return path + src
+  if (!src.includes(path)) {
+    return path + src
   }
   return src
 }
@@ -30,7 +30,7 @@ class Image extends React.Component {
       : null
     const source = internalLink ? addPath(localImage.src) : src
     const placeholder = internalLink ? localImage.placeholder : null
-
+    console.log(localImage)
     const Placeholder = () =>
       !noBlur || !internalLink ? (
         <StyledImage.Placeholder>
@@ -39,8 +39,16 @@ class Image extends React.Component {
         </StyledImage.Placeholder>
       ) : null
 
+    // If it's a local image, pass down the height and width to our image styled component
+    const imageProps = localImage
+      ? {
+          width: localImage.width,
+          height: localImage.height
+        }
+      : {}
+
     return (
-      <StyledImage noBlur={noBlur}>
+      <StyledImage noBlur={noBlur} {...imageProps}>
         <StyledImage.Picture.Wrapper>
           <StyledImage.Picture {...rest}>
             <img data-src={source} alt={alt} className="lazyload" />


### PR DESCRIPTION
### What this does

This fixes a bug where if an image was smaller than its container, the placeholder blurred image would extend to 100%, whereas the image itself would be its smaller width. This passes the width of the image to the image component and allows for images to exist smaller than their containers width (they will never go beyond 100%).

#### Before
![screen shot 2018-10-09 at 12 49 22 pm](https://user-images.githubusercontent.com/11803153/46687944-c5a74300-cbc1-11e8-9438-f7d3fcb25ab2.png)

#### After
![screen shot 2018-10-09 at 12 49 48 pm](https://user-images.githubusercontent.com/11803153/46687968-d3f55f00-cbc1-11e8-94a3-9bdb27a46e0c.png)
