### PR TITLE
Hotfix to remove blog fetch

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -12,9 +12,6 @@ import { Provider as ReduxProvider } from 'redux-bundler-react'
 import { styles } from '@common/legacy-styles'
 
 const fetchOurData = async (ctx) => {
-  if (!ctx.reduxStore.selectBlogPosts()) {
-    await ctx.reduxStore.doFetchBlogData()
-  }
   if (!ctx.reduxStore.selectJobs()) {
     await ctx.reduxStore.doFetchJobsData()
   }


### PR DESCRIPTION
We no longer use the static file generation of blog posts, so we shouldn't be fetching the blog posts in the website app.

This was causing the builds to fail for me (should have been failing for others too).

Caveat: I do not really know what this does, so someone sanity check this. 