### PR TITLE
fix discord link and badge formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 
 ## Blockstack.org
 
-[![Discord](https://img.shields.io/discord/621759717756370964](http://chat.blockstack.org)
+[![Discord](https://img.shields.io/discord/621759717756370964)](https://chat.blockstack.org)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat)](http://makeapullrequest.com)
 
 A live version of this site can be found online at https://blockstack.org.


### PR DESCRIPTION
Fixes half of #1035, for the other half I am not sure where to find the logo image.