### PR TITLE
removed image to match other repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,4 @@
 <p align="center">
-  <br>
-  <a href="https://blockstack.org">
-    <img src="https://media.githubusercontent.com/media/blockstack/designs/master/logo/RGB/bug/blockstack-bug-rounded-256x256.png" width=72 height=72>
-  </a>
-
   <h3 align="center">Blockstack.org</h3>
 
   <p align="center">


### PR DESCRIPTION
Quick fix for #1035 by removing link and image tags. Matches format of other repos:

https://github.com/blockstack/blockstack-core
https://github.com/blockstack/gaia
https://github.com/blockstack/docs.blockstack