### PR TITLE
Update SIPs link

### DIFF
--- a/pages/papers/index.js
+++ b/pages/papers/index.js
@@ -135,7 +135,7 @@ class PapersPage extends React.PureComponent {
               Latest Stacks Improvement Proposals (SIPs) are available on{' '}
               <Section.Text
                 is="a"
-                href="https://github.com/blockstack/blockstack-core/tree/develop/sip"
+                href="https://github.com/blockstack/blockstack-core/tree/master/sip"
                 target="_blank"
               >
                 GitHub

--- a/pages/technology/index.js
+++ b/pages/technology/index.js
@@ -58,7 +58,7 @@ const resources = [
       },
       {
         label: 'Stacks Improvement Proposals',
-        href: 'https://github.com/blockstack/blockstack-core/tree/develop/sip'
+        href: 'https://github.com/blockstack/blockstack-core/tree/master/sip'
       }
     ]
   }


### PR DESCRIPTION
So it uses `master` instead of `develop`